### PR TITLE
fix pc auto ipset proxy bug （compatible with iOS)

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -390,7 +390,7 @@ func searchGreySong(data common.MapType, netease *Netease) bool {
 				//data["url"] = uri.Scheme + "://" + uri.Host + uri.EscapedPath()
 				//data["url"] = uri.String()
 				if *config.EndPoint{
-					data["url"]="https://music.163.com/unblockmusic/"+uri.String()
+					data["url"]="http://music.163.com/unblockmusic/"+uri.String()
 				}else{
 					data["url"] = uri.String()
 				}


### PR DESCRIPTION
https://music.163.com/unblockmusic/ 会造成 pc 版本不能自动代理，改为 
http://music.163.com/unblockmusic/ 即可，不影响 iOS 版本