### PR TITLE
Revert "fix can't unlock iOS new version"

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -393,7 +393,7 @@ func searchGreySong(data common.MapType, netease *Netease) bool {
 				//data["url"] = uri.Scheme + "://" + uri.Host + uri.EscapedPath()
 				//data["url"] = uri.String()
 				if *config.EndPoint {
-					data["url"] = "https://music.163.com/unblockmusic/" + uri.String()
+					data["url"] = "http://music.163.com/unblockmusic/" + uri.String()
 				} else {
 					data["url"] = uri.String()
 				}


### PR DESCRIPTION
Reverts cnsilvan/UnblockNeteaseMusic#19
会造成vip解锁失败，暂时取消