### PR TITLE
fix can not play music on Windows client

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -394,6 +394,31 @@ func searchGreySong(data common.MapType, netease *Netease) bool {
 				//data["url"] = uri.String()
 				if *config.EndPoint {
 					data["url"] = "https://music.163.com/unblockmusic/" + uri.String()
+
+					//if os is Windows, use http not https.
+					if headerIntf, ok := netease.Params["header"]; ok {
+						if headerStr, ok := headerIntf.(string); ok {
+							header := utils.ParseJson([]byte(headerStr))
+							if osIntf, ok := header["os"]; ok {
+								if os, ok := osIntf.(string); ok {
+									if os == "pc" {
+										data["url"] = "http://music.163.com/unblockmusic/" + uri.String()
+									}
+								}
+							}
+						}
+
+						if header, ok := headerIntf.(map[string]interface{}); ok {
+							if osIntf, ok := header["os"]; ok {
+								if os, ok := osIntf.(string); ok {
+									if os == "pc" {
+										data["url"] = "http://music.163.com/unblockmusic/" + uri.String()
+									}
+								}
+							}
+						}
+					}
+
 				} else {
 					data["url"] = uri.String()
 				}


### PR DESCRIPTION
最新版本配合luci在软路由解锁后，windows客户端无法播放解锁歌曲。

#19 引入的问题。
经调试后问题为windows客户端对https请求不完全支持导致。windows请求正常的歌曲是通过http，经过抓包后分析， 开启-e flag后， #19 后会把请求换成https，而windows客户端好像不能正确处理这里的https请求。具体表现为发送Client Hello、接收Server Hello之后便发送Alert并断开连接。不清楚这里断开是因为什么原因（服务器证书验证，还是返回的信息不对，或是客户端自身逻辑缺陷等），需要进一步调查。尝试过修改music.163.com为interface.music.163.com等host，均无效。

这里采用的解决办法是识别是否为windows客户端，如果是的话就使用http进行连接。已测试windows客户端、Android客户端、iOS iPad版网易云音乐HD，可正常工作，其他客户端由于缺乏设备没做测试。如果有其他客户端不支持https音乐播放，可在客户端识别处加上其名称，应该可以解决问题。