### PR TITLE
Update auto_release.yml

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -42,7 +42,7 @@ jobs:
           GitCommit=$(git rev-parse --short HEAD || echo unsupported)
           GoVersion=$(go version)
           BuildTime=$(TZ=UTC-8 date "+%Y-%m-%d %H:%M:%S")
-          platforms=("windows/amd64" "darwin/amd64" "linux/arm" "linux/amd64" "linux/arm5" "linux/arm6" "linux/arm7" "linux/mipsle" "linux/mips" "linux/mipsle-softfloat" "linux/mips-softfloat" "linux/386")
+          platforms=("windows/amd64" "darwin/amd64" "linux/arm" "linux/amd64" "linux/arm5" "linux/arm64" "linux/arm7" "linux/mipsle" "linux/mips" "linux/mipsle-softfloat" "linux/mips-softfloat" "linux/386")
           #platforms=("windows/amd64" "darwin/amd64")
           buildGo() {
            GOOS=$1
@@ -59,10 +59,10 @@ jobs:
                GOARCH="arm"
                GOARM="GOARM=5"
                suffix="5"
-           elif [ $GOARCH = "arm6" ]; then
-               GOARCH="arm"
-               GOARM="GOARM=6"
-               suffix="6"
+           elif [ $GOARCH = "arm64" ]; then
+               GOARCH="arm64"
+               GOARM=""
+               suffix=""
            elif [ $GOARCH = "arm7" ]; then
                GOARCH="arm"
                GOARM="GOARM=7"


### PR DESCRIPTION
国内家用arm路由基本就是以bcm4709没有fpu为代表的使用armv5，和以bcm6750/ipq4019/ipq8064有fpu为代表的使用armv7，这两者可以合并使用armv5，没有人用armv6，arm64是以bcm4908和ipq8074为代表的aarch64，这两者有fpu且可以在固件允许的情况下使用armv5