### PR TITLE
fix(utils): 未进行字符串序列化导致某些语言无法匹配

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cnsilvan/UnblockNeteaseMusic/cookiestxt"
+	"golang.org/x/text/unicode/norm"
 	"io"
 	"io/ioutil"
 	"log"
@@ -142,8 +143,8 @@ func GenRandomBytes(size int) (blk []byte, err error) {
 
 func CalMatchScoresV2(beMatchedData string, beSplitedData string, matchType string) float32 {
 	var score float32 = 0.0
-	beMatchedData = width.Narrow.String(strings.ToUpper(strings.TrimSpace(beMatchedData)))
-	beSplitedData = width.Narrow.String(strings.ToUpper(strings.TrimSpace(beSplitedData)))
+	beMatchedData = width.Narrow.String(strings.ToUpper(strings.TrimSpace(norm.NFC.String(beMatchedData))))
+	beSplitedData = width.Narrow.String(strings.ToUpper(strings.TrimSpace(norm.NFC.String(beSplitedData))))
 	orginData := beMatchedData
 	if len(beMatchedData) < len(beSplitedData) {
 		orginData = beSplitedData


### PR DESCRIPTION
例如日语，日语的浊点可以单占一个字符，也可以和假名合并成一个字符，如：
`たﾞ  だ`
这种情况需要把它序列化为一个字符才能进行比对。
类似情况我查到了一个 *[python的issue](https://github.com/JeromeLefebvre/JapaneseCounting/issues/3)*